### PR TITLE
debian/control: add missing build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: hello
 Section: misc
 Priority: extra
 Maintainer: Baurzhan Ismagulov <ibr@radix50.net>
-Build-Depends: debhelper (>= 9), autotools-dev
+Build-Depends: debhelper (>= 9), autotools-dev, docbook-to-man
 Standards-Version: 3.9.5
 Homepage: https://github.com/ilbers/hello
 


### PR DESCRIPTION
Wed Sep 13 18:37:47 2017 -- docbook-to-man hello.sgml >hello.1
Wed Sep 13 18:37:47 2017 -- /bin/bash: docbook-to-man: command not found
Wed Sep 13 18:37:47 2017 -- Makefile:811: recipe for target 'hello.1' failed
Wed Sep 13 18:37:47 2017 -- make[2]: *** [hello.1] Error 127

Signed-off-by: Manuel Traut <manut@linutronix.de>